### PR TITLE
alias run to _run for Ruby 1.9.2

### DIFF
--- a/lib/minitest-chef-handler.rb
+++ b/lib/minitest-chef-handler.rb
@@ -8,6 +8,8 @@ module MiniTest
         Dir.glob(path).each {|test_suite| require test_suite}
 
         @options = options
+
+        MiniTest::Unit.class_eval{ alias :_run :run } if RUBY_VERSION == "1.9.2"
       end
 
       def report


### PR DESCRIPTION
Workaround run method naming on Ruby 1.9.2 for MiniTest::Unit._run, closes #3
