### PR TITLE
Fail chef run if there are minitest errors. Fixes #29

### DIFF
--- a/lib/minitest-chef-handler.rb
+++ b/lib/minitest-chef-handler.rb
@@ -38,7 +38,7 @@ module MiniTest
           runner.run(miniunit_options)
         end
 
-        if [runner.failures, runner.errors].any?(&:nonzero?)
+        if runner.failures.nonzero? || runner.errors.nonzero?
           ::Chef::Client.when_run_completes_successfully do |run_status|
             raise "MiniTest failed with #{runner.failures} failure(s) and #{runner.errors} error(s)."
           end


### PR DESCRIPTION
Here's a very basic fix. I played around with doing a module or a private method but neither felt right to me. I'd also be happy to do a test, but I didn't see any failure testing already in place. Should it maybe be a sibling to simple-solo? failing-solo, perhaps?
