### PR TITLE
Add spec for MiniTest::Chef::Spec.

### DIFF
--- a/lib/minitest-chef-handler/spec.rb
+++ b/lib/minitest-chef-handler/spec.rb
@@ -1,6 +1,7 @@
 module MiniTest
   module Chef
     require 'minitest/spec'
+    require 'minitest-chef-handler/assertions'
 
     class Spec < MiniTest::Spec
       include Assertions

--- a/spec/minitest-chef-handler/spec_spec.rb
+++ b/spec/minitest-chef-handler/spec_spec.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+describe MiniTest::Chef::Spec do
+
+  let(:spec) { Class.new(MiniTest::Chef::Spec).new(:sample_spec) }
+
+  it "makes the node object available" do
+    spec.must_respond_to(:node)
+  end
+
+  it "makes minitest-chef-handler assertions available" do
+    spec.must_respond_to(:assert_installed)
+  end
+
+  it "makes minitest-chef-handler resource helpers available" do
+    spec.must_respond_to(:package)
+  end
+end


### PR DESCRIPTION
Hi David,

I've tweaked `MiniTest::Chef::Spec` so that classes which subclass it will be able to use the assertions from `MiniTest::Chef::Assertions` without the need to include that module separately.

Cheers,

Andrew.
