### PR TITLE
Fixes issue 34: Invalid include.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,10 @@
+=== 0.6.4 / 12-02-2012
+
+* 1 bug fix:
+
+  * No longer directly include MiniTest::Assertions in order to avoid using the wrong mixins.
+    Resolves issue 34. Reported by Leif Madsen (@leifmadsen). Fix suggested by Andrew Crump (@acrmp).
+
 === 0.6.3 / 09-25-2012
 
 * 1 bug fix:

--- a/lib/minitest-chef-handler/resources.rb
+++ b/lib/minitest-chef-handler/resources.rb
@@ -35,10 +35,10 @@ module MiniTest
       register_resource(:mount, :device)
 
       ::Chef::Resource.class_eval do
-        include MiniTest::Assertions
         def with(attribute, values)
+          mt = Object.extend(MiniTest::Assertions)
           actual_values = resource_value(attribute)
-          assert_equal values, actual_values,
+          mt.assert_equal values, actual_values,
             "The #{resource_name} does not have the expected #{attribute}"
           self
         end

--- a/minitest-chef-handler.gemspec
+++ b/minitest-chef-handler.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |gem|
   gem.authors       = ["David Calavera"]
   gem.email         = ["david.calavera@gmail.com"]
-  gem.description   = %q{Run Minitest suites as Chef report handlers}
+  gem.description   = %q{Run minitest suites after your Chef recipes to check the status of your system.}
   gem.summary       = %q{Run Minitest suites as Chef report handlers}
   gem.homepage      = ""
 
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "minitest-chef-handler"
   gem.require_paths = ["lib"]
-  gem.version       = '0.6.3'
+  gem.version       = '0.6.4'
 
   gem.add_dependency('minitest')
   gem.add_dependency('chef')


### PR DESCRIPTION
Resolves issue 34 by not directly including the MiniTest::Assertions module. Rather,
we extend the usage of MiniTest::Assertions.
