### PR TITLE
Add report to the exception so other handlers can use it

### DIFF
--- a/lib/minitest-chef-handler.rb
+++ b/lib/minitest-chef-handler.rb
@@ -43,7 +43,9 @@ module MiniTest
 
         if runner.failures.nonzero? || runner.errors.nonzero?
           ::Chef::Client.when_run_completes_successfully do |run_status|
-            raise "MiniTest failed with #{runner.failures} failure(s) and #{runner.errors} error(s)."
+            error_msg = "MiniTest failed with #{runner.failures} failure(s) and #{runner.errors} error(s).\n"
+            error_msg << runner.report.sort.join("\n")
+            raise error_msg
           end
         end
       end


### PR DESCRIPTION
This add a bit more of information to the exception with may be useful for others handlers.

If you're using others handlers (e.g. [chef-handler-mail](https://rubygems.org/gems/chef-handler-mail), [chef-handler-s3](https://rubygems.org/gems/chef-handler-s3)...) to send or store the reports elsewhere, right now you don't get any information about which test has fail.
Adding this line the you can use the `run_status.exception` or the `run_status.formatted_exception` to see wich test did fail.

For example, instead of have this `run_status.formatted_exception`:

```
RuntimeError: MiniTest failed with 1 failure(s) and 0 error(s).
```

You could have something like this:

```
MiniTest failed with 2 failure(s) and 0 error(s).
Failure:
test_0002_must_own_to_the_root(recipe::spec_examples::default::config file::only the root can modify the config file) [/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/minitest-chef-handler-0.6.4/lib/minitest-chef-handler/resources.rb:41]:
The file does not have the expected owner.
Expected: "oot"
  Actual: "root"
```

Much more useful.
I hope you like it and thanks for this great handler :smile: 
