### PR TITLE
fix autodiscover of used recipes for Chef 11

### DIFF
--- a/lib/minitest-chef-handler/lookup.rb
+++ b/lib/minitest-chef-handler/lookup.rb
@@ -60,7 +60,8 @@ module MiniTest
         if recipes = run_status.node.run_state[:seen_recipes]
           recipes.keys
         else
-          run_status.node.run_list.select(&:recipe?).map(&:name)
+          # chef 11 - see http://docs.opscode.com/breaking_changes_chef_11.html#node-run-state-replaced
+          run_status.run_context.loaded_recipes
         end
       end
 


### PR DESCRIPTION
Rake tests are failing but as discussed, this is a known issue 
