### PR TITLE
put mode logic and filename reporting into resource so everybody can benefit

### DIFF
--- a/lib/minitest-chef-handler/assertions.rb
+++ b/lib/minitest-chef-handler/assertions.rb
@@ -135,32 +135,22 @@ module MiniTest
       end
 
       def assert_acl(file, owner, group, mode)
-        mode = mode.to_s(8) if mode.is_a?(Integer) # better diff since 0755 would be converted to 493
-        mode = mode.sub(/^0+/, "")
-
-        file_resource = file(file)
-        file_mode = file_resource.mode
-        file_mode = if file_mode.is_a?(Integer) # chef 10/11
-          file_mode.to_s(8)
-        else
-          file_mode.sub(/^0+/, "")
-        end
-
-        assert_equal owner, file_resource.owner, "Expected #{file} to have owner #{owner}, not #{file_resource.owner}"
-        assert_equal group, file_resource.group, "Expected #{file} to have group #{group}, not #{file_resource.group}"
-        assert_equal mode, file_mode, "Expected #{file} to have mode #{mode}, not #{file_mode}"
+        file(file).
+          must_have(:owner, owner).
+          must_have(:group, group).
+          must_have(:mode, mode)
       end
 
       def assert_symlinked_file(file, *args)
         assert File.symlink?(file), "Expected #{file} to be a symlink"
-        assert_acl file, *args
         assert File.read(file, 1), "Expected #{file} to be linked to an existing file"
+        assert_acl file, *args
       end
 
       def assert_symlinked_directory(directory, *args)
         assert File.symlink?(directory), "Expected #{directory} to be a symlink"
-        assert_acl directory, *args
         assert_sh "ls #{directory}/", "Expected #{directory} to link to an existing directory"
+        assert_acl directory, *args
       end
 
       def assert_logrotate(file)

--- a/spec/minitest-chef-handler/resources_spec.rb
+++ b/spec/minitest-chef-handler/resources_spec.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
 describe MiniTest::Chef::Resources do
-
   let(:resources) { Class.new{ include MiniTest::Chef::Resources }.new }
 
   it "provides convenient access to current resource state" do
@@ -36,13 +35,13 @@ describe MiniTest::Chef::Resources do
         and(:backup, 5).must_equal(file)
     end
     it "fails if the assertion is not met" do
-      assert_triggered(/The file does not have the expected name/) do
+      assert_triggered("The file /etc/foo does not have the expected name") do
         file.must_have(:name, '/etc/bar')
       end
-      assert_triggered(/The file does not have the expected action/) do
+      assert_triggered("The file /etc/foo does not have the expected action") do
         file.must_have(:name, '/etc/foo').with(:action, 'delete')
       end
-      assert_triggered(/The file does not have the expected action/) do
+      assert_triggered("The file /etc/foo does not have the expected action") do
         file.must_have(:name, '/etc/foo').and(:action, 'delete')
       end
     end
@@ -56,6 +55,28 @@ describe MiniTest::Chef::Resources do
 
       assert_triggered(/Expected: "755"\n  Actual: nil/) do
         file.must_have(:mode, '755')
+      end
+    end
+
+    [["integer", 0755], ["string", "0755"]].each do |type, mode|
+      it "fails with incorrect modes on #{type} mode" do
+        file.define_singleton_method(:mode){ mode }
+        def file.mode; 0755; end
+        assert_triggered(/Expected: "644"\n  Actual: "755"/) do
+          file.must_have(:mode, 0644)
+        end
+        assert_triggered(/Expected: "644"\n  Actual: "755"/) do
+          file.must_have(:mode, 0644)
+        end
+      end
+
+      it "passes with correct modes on #{type} mode" do
+        file.define_singleton_method(:mode){ mode }
+        file.must_have(:mode, '00755')
+        file.must_have(:mode, '00755')
+        file.must_have(:mode, '0755')
+        file.must_have(:mode, '755')
+        file.must_have(:mode, 0755)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,9 @@ def assert_triggered(expected)
   msg = e.message.sub(/(---Backtrace---).*/m, '\1')
   msg.gsub!(/\(oid=[-0-9]+\)/, '(oid=N)')
 
-  assert_match expected, msg
+  if expected.is_a?(String)
+    assert_includes msg, expected
+  else
+    assert_match expected, msg
+  end
 end


### PR DESCRIPTION
Just noticed that this whole mode conversion logic already existed in resource,
so we should reuse it (I also expanded it a little).
I also made all must_have report the path if the method exists so it's easy to track back what exactly failed.

@calavera
