### PR TITLE
Output to stdout in addition to a log file

### DIFF
--- a/lib/minitest-chef-handler/core_ext.rb
+++ b/lib/minitest-chef-handler/core_ext.rb
@@ -1,12 +1,39 @@
 class Chef
   class Log
+    # Intercept any output from minitest
     def self.puts(*a)
-      self.<< "\n" if a.empty?
-      a.each {|m| self.<< m; self.<< "\n"}
+      if a.empty?
+        self.output "\n"
+      else 
+        a.each do |m| 
+          self.output "#{m}\n"
+        end
+      end
     end
 
     def self.print(*a)
-      a.each {|m| self.<< m}
+      a.each do |m| 
+        self.output m
+      end
+    end
+
+    # Pass messages to chef::Log's standard output stream
+    # Additionally log to STDOUT if not already doing so
+    def self.output(message)  
+      self << message
+      if !self.logging_to_stdout?
+        ios = IO.new STDOUT.fileno
+        ios.write message
+        ios.close
+      end
+    end
+
+    # look deep into the bowels of Chef::Log to see if it is
+    # logging to stdout or not
+    # There _must_ be a better way of doing this :-/
+    def self.logging_to_stdout?
+      logdev = self.logger.instance_variable_get(:@logdev).instance_variable_get(:@dev)
+      logdev == STDOUT
     end
   end
 end


### PR DESCRIPTION
When chef is configured to use a log file then minitest (correctly) writes its output to the same file, but the output is then missing from stdout. This commit ensures minitest outputs to both locations when appropriate

The bit of code that detects if chef is logging to stdout is hideous, there must be a better way of doing this but my ruby/chef foo is limited :(

Fixes #75