### PR TITLE
Add a #refute_sh negative assertion for sh commands, and specs for it.

### DIFF
--- a/lib/minitest-chef-handler/assertions.rb
+++ b/lib/minitest-chef-handler/assertions.rb
@@ -169,6 +169,12 @@ module MiniTest
         out
       end
 
+      def refute_sh(command, text=nil)
+        text ||= "Expected #{commnd} not to succeed"
+        out = `#{command} 2>&1`
+        assert !$?.success?, "#{text}, but succeeded with: #{out}"
+        out
+      end
     end
   end
 end

--- a/spec/minitest-chef-handler/assertions_spec.rb
+++ b/spec/minitest-chef-handler/assertions_spec.rb
@@ -460,4 +460,16 @@ describe MiniTest::Chef::Assertions do
       end
     end
   end
+
+  describe "#refute_sh" do
+    it "succeeds when the command fails" do
+      refute_sh("false")
+    end
+
+    it "fails when the command succeeds" do
+      assert_triggered "Expected true not to succeed, but succeeded with: ABC" do
+        refute_sh("echo ABC && true")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a simple addition for refuting `sh` commands.
