### PR TITLE
fix assert_directory returns 'nil' instead of owner/group of the directory

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,8 @@
+=== 1.0.2 / 01-02-2014
+* 1 bug fix:
+
+  * Fix assert_directory returns nil instead of owner/group of the directory
+
 === 1.0.1 / 04-24-2013
 
 * 1 bug fix:

--- a/examples/spec_examples/files/default/tests/minitest/default_test.rb
+++ b/examples/spec_examples/files/default/tests/minitest/default_test.rb
@@ -91,11 +91,10 @@ describe_recipe 'spec_examples::default' do
 
     # The file existence and permissions matchers are also valid for
     # directories:
-    # FIXME: Actual value found for owner is nil!
-    it "creates directories" #do
-    #  directory("/etc/").must_exist.with(:owner, "root")
-    #  assert_directory "/etc", "root", "root", 0755
-    #end
+    it "creates directories" do
+      directory("/etc/").must_exist.with(:owner, "root")
+      assert_directory "/etc", "root", "root", 0755
+    end
 
     # = Links =
 

--- a/lib/minitest-chef-handler/assertions.rb
+++ b/lib/minitest-chef-handler/assertions.rb
@@ -139,10 +139,17 @@ module MiniTest
       end
 
       def assert_acl(file, owner, group, mode)
-        file(file).
-          must_have(:owner, owner).
-          must_have(:group, group).
-          must_have(:mode, mode)
+        unless File.directory?(file)
+          file(file).
+            must_have(:owner, owner).
+            must_have(:group, group).
+            must_have(:mode, mode)
+        else
+          directory(file).
+            must_have(:owner, owner).
+            must_have(:group, group).
+            must_have(:mode, mode)
+        end
       end
 
       def assert_symlinked_file(file, *args)

--- a/minitest-chef-handler.gemspec
+++ b/minitest-chef-handler.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "minitest-chef-handler"
   gem.require_paths = ["lib"]
-  gem.version       = '1.0.1'
+  gem.version       = '1.0.2'
 
   gem.add_dependency('minitest', '~> 4.7.3')
   gem.add_dependency('chef', '>= 10.12.0')


### PR DESCRIPTION
Tested and verified to fix Issue #74
