### PR TITLE
Constrain ci_reporter dependency to < 2.0

### DIFF
--- a/minitest-chef-handler.gemspec
+++ b/minitest-chef-handler.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('minitest', '~> 4.7.3')
   gem.add_dependency('chef', '>= 10.12.0')
-  gem.add_dependency('ci_reporter')
+  gem.add_dependency('ci_reporter', '< 2.0')
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "appraisal"


### PR DESCRIPTION
ci_reporter 2.0 was just released and it breaks minitest-chef-handler
as follows:

```
LoadError: cannot load such file -- ci/reporter/minitest
```

Until we're fully compatible with ci_reporter 2.0, this should resolve
the issue.
