### PR TITLE
Strip commands before assert/refute_sh

### DIFF
--- a/lib/minitest-chef-handler/assertions.rb
+++ b/lib/minitest-chef-handler/assertions.rb
@@ -171,14 +171,14 @@ module MiniTest
 
       def assert_sh(command, text=nil)
         text ||= "Expected #{command} to succeed"
-        out = `#{command} 2>&1`
+        out = `#{command.strip} 2>&1`
         assert $?.success?, "#{text}, but failed with: #{out}"
         out
       end
 
       def refute_sh(command, text=nil)
         text ||= "Expected #{command} not to succeed"
-        out = `#{command} 2>&1`
+        out = `#{command.strip} 2>&1`
         assert !$?.success?, "#{text}, but succeeded with: #{out}"
         out
       end

--- a/spec/minitest-chef-handler/assertions_spec.rb
+++ b/spec/minitest-chef-handler/assertions_spec.rb
@@ -25,6 +25,14 @@ describe MiniTest::Chef::Assertions do
     file
   end
 
+  def directory(path)
+    directory = ::Chef::Resource::Directory.new(path)
+    def directory.mode; 0755;end
+    def directory.owner; "xxx";end
+    def directory.group; "xxx";end
+    directory
+  end
+
   module MiniTest::Chef::Assertions
     class File
       def self.read(path, to=-1)
@@ -339,19 +347,19 @@ describe MiniTest::Chef::Assertions do
     end
 
     it "verifies that it has the correct owner" do
-      assert_triggered "The file /etc does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
+      assert_triggered "The directory /etc does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
         assert_acl("/etc", "foo", "bar", 0755)
       end
     end
 
     it "verifies that it has the correct group" do
-      assert_triggered "The file /etc does not have the expected group.\nExpected: \"bar\"\n  Actual: \"family\"" do
+      assert_triggered "The directory /etc does not have the expected group.\nExpected: \"bar\"\n  Actual: \"family\"" do
         assert_acl("/etc", "me", "bar", 0755)
       end
     end
 
     it "verifies that it has the correct mode" do
-      assert_triggered "The file /etc does not have the expected mode.\nExpected: \"750\"\n  Actual: \"755\"" do
+      assert_triggered "The directory /etc does not have the expected mode.\nExpected: \"750\"\n  Actual: \"755\"" do
         assert_acl("/etc", "me", "family", 0750)
       end
     end
@@ -369,7 +377,7 @@ describe MiniTest::Chef::Assertions do
     end
 
     it "verifies that it has the correct acl" do
-      assert_triggered "The file /etc does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
+      assert_triggered "The directory /etc does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
         assert_directory("/etc", "foo", "bar", 0755)
       end
     end
@@ -426,7 +434,7 @@ describe MiniTest::Chef::Assertions do
     end
 
     it "verifies that it has the correct acl" do
-      assert_triggered "The file /etc/gar does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
+      assert_triggered "The directory /etc/gar does not have the expected owner.\nExpected: \"foo\"\n  Actual: \"me\"" do
         assert_symlinked_directory("/etc/gar", "foo", "bar", 0755)
       end
     end

--- a/spec/minitest-chef-handler/assertions_spec.rb
+++ b/spec/minitest-chef-handler/assertions_spec.rb
@@ -475,7 +475,7 @@ describe MiniTest::Chef::Assertions do
     end
 
     it "fails when the command succeeds" do
-      assert_triggered "Expected true not to succeed, but succeeded with: ABC" do
+      assert_triggered "Expected echo ABC && true not to succeed, but succeeded with: ABC" do
         refute_sh("echo ABC && true")
       end
     end


### PR DESCRIPTION
Any time I need something more than a simple one-liner, I reach for a heredoc because they read a lot nicer. Unfortunately heredocs can easily end up with a trailing newline. If we don't strip the newline we end up executing `2>&1` by itself masking the return value of the user-specified command.

As an example

``` console
irb(main):001:0> command = <<-SH
irb(main):002:0" false
irb(main):003:0" SH
=> "false\n"
irb(main):004:0> `#{command} 2>&1`
=> ""
irb(main):005:0> puts $?
pid 2509 exit 0
```

Stripping before we run the commands avoids this.

Also includes a couple commits to get the test suite green again.
